### PR TITLE
replace hadleyverse with tidyverse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM rocker/hadleyverse
+FROM rocker/tidyverse
 MAINTAINER Marc A. Suchard <msuchard@ucla.edu>
 
-RUN apt-get update && apt-get install -y python-dev
+RUN apt-get update && apt-get install -y python-dev openjdk-8-jdk liblzma-dev libbz2-dev \
+&& R CMD javareconf
 
 ## Install Rserve
 RUN install2.r \
@@ -17,9 +18,9 @@ RUN install2.r \
 RUN installGithub.r \
 	OHDSI/SqlRender \
 	OHDSI/DatabaseConnector \
+	OHDSI/OhdsiRTools \
 	OHDSI/Achilles \
 	OHDSI/Cyclops \
-	OHDSI/OhdsiRTools \
 	OHDSI/FeatureExtraction \
 	OHDSI/BigKnn \
 	OHDSI/PatientLevelPrediction \
@@ -28,9 +29,7 @@ RUN installGithub.r \
 	hadley/xml2 \
 	cloudyr/aws.s3 \
 	OHDSI/OhdsiSharing \
-	OHDSI/StudyProtocols/KeppraAngioedema \
 && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
-
 
 COPY Rserv.conf /etc/Rserv.conf
 COPY startRserve.R /usr/local/bin/startRserve.R


### PR DESCRIPTION
@lmendezboo kindly provided the changes to replace hadleyverse with tidyverse:
 
"rocker/hadlyeverse is phasing out and mostly unmaintained (latest build 9 months ago)"

Other changes included:

- Remove the OHDSI/StudyProtocols/KeppraAngioedema study package (no need to include it in this general purpose OHDSI Methods container)
- Reorder package install list to accommodate new OhdsiRTools package dependency in latest Achilles R package 
